### PR TITLE
Prepare 0.2.0 Release (Docker, Versioning, SDK Updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## 0.2.0 — 2026-03-31
+- Added Docker distribution
+- Fixed npm SDK bug
+- Unified versioning across all SDKs
+- Added server version injection
+
 
 ## [Unreleased - v0.1.3] – 31 March 2026
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # build stage
 FROM golang:1.25 AS builder
 
+ARG VERSION=dev
+
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
@@ -12,8 +14,7 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o /bin/minikms ./cmd/main.go
-
+RUN go build -ldflags="-X github.com/michaeljmartin28/minikms/package/version.Version=$VERSION" -o /bin/minikms ./cmd/main.go
 
 # runtime stage
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# build stage
+FROM golang:1.25 AS builder
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN go build -o /bin/minikms ./cmd/main.go
+
+
+# runtime stage
+FROM gcr.io/distroless/static-debian12:nonroot
+
+WORKDIR  /app
+
+COPY --from=builder /bin/minikms /app/minikms
+
+EXPOSE 8080
+EXPOSE 9090
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/app/minikms"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -17,11 +18,12 @@ import (
 	"github.com/michaeljmartin28/minikms/internal/storage"
 	"github.com/michaeljmartin28/minikms/internal/transport/grpcsrv"
 	"github.com/michaeljmartin28/minikms/internal/transport/httpsrv"
+	"github.com/michaeljmartin28/minikms/package/version"
 	"google.golang.org/grpc"
 )
 
 func main() {
-
+	fmt.Printf("miniKMS %s starting...\n", version.Version)
 	cfg := config.Load()
 
 	store, err := storage.NewBoltStore(cfg.DBPath)

--- a/package/sdk/node/package.json
+++ b/package/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minikms/sdk",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Official Node.js SDK for miniKMS",
   "keywords": [
     "minikms",

--- a/package/sdk/node/src/client.ts
+++ b/package/sdk/node/src/client.ts
@@ -50,7 +50,7 @@ export class Client {
   encrypt(keyId: string, req: EncryptRequest) {
     const body = {
       plaintext: this.toBase64(req.plaintext),
-      additionalData: this.toBase64(req.additionalData),
+      additionalData: this.toBase64(req?.additionalData),
     };
     return this.do<EncryptResponse>("POST", `/v1/keys/${keyId}/encrypt`, body);
   }
@@ -58,7 +58,7 @@ export class Client {
   decrypt(keyId: string, req: DecryptRequest) {
     const body = {
       ciphertext: req.ciphertext,
-      additionalData: this.toBase64(req.additionalData),
+      additionalData: this.toBase64(req?.additionalData),
       version: req.version,
     };
     return this.do<DecryptResponse>(
@@ -70,7 +70,7 @@ export class Client {
 
   generateDataKey(keyId: string, req: GenerateDataKeyRequest) {
     const body = {
-      additionalData: this.toBase64(req.additionalData),
+      additionalData: this.toBase64(req?.additionalData),
     };
     return this.do<GenerateDataKeyResponse>(
       "POST",
@@ -87,7 +87,7 @@ export class Client {
     const body = {
       encryptedDEK: req.encryptedDEK, // already base64
       version: req.version,
-      additionalData: this.toBase64(req.additionalData),
+      additionalData: this.toBase64(req?.additionalData),
     };
     return this.do<DecryptDataKeyResponse>(
       "POST",

--- a/package/sdk/python/pyproject.toml
+++ b/package/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "minikms"
-version = "0.1.3"
+version = "0.2.0"
 description = "Python SDK for miniKMS"
 authors = [
     { name = "Michael Martin" }

--- a/package/version/version.go
+++ b/package/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version = "dev"


### PR DESCRIPTION
This PR prepares the repository for the 0.2.0 release of miniKMS.
It introduces unified versioning across the server, Docker image, and all SDKs, fixes a bug in the npm SDK, and adds version injection support to the server build.

## Changes
### Server

- Added package/version with exported Version variable
- Added version injection via -ldflags in Docker build
- Updated startup to reference the version package
- Ensured version is included in the final binary

### Docker

- Added multi‑stage Dockerfile with:
- static Go build (CGO_ENABLED=0)
- version injection via ARG VERSION
- distroless runtime image
- non‑root execution
- Verified build context and corrected build paths

### SDKs

- npm: fixed minor bug, bumped version to 0.2.0
- Python: bumped version to 0.2.0
- Go module: prepared for v0.2.0 tag

### Repo

- Updated version references across code and docs
- Prepared for unified release workflow